### PR TITLE
Explicitly set AWS policy version

### DIFF
--- a/aws_iam_role.cwl.tf
+++ b/aws_iam_role.cwl.tf
@@ -9,7 +9,8 @@ resource "aws_iam_role" "cwl" {
         "Service": "logs.${data.aws_region.current.name}.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
-    }
+    },
+    "Version": "2012-10-17"
 }
 EOF
 }

--- a/aws_iam_role.firehosetos3.tf
+++ b/aws_iam_role.firehosetos3.tf
@@ -9,7 +9,8 @@ resource "aws_iam_role" "firehosetos3" {
         "Service": "firehose.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
-    }
+    },
+    "Version": "2012-10-17"
   }
 EOF
 }

--- a/data.aws_iam_policy_document.cloudwatch.tf
+++ b/data.aws_iam_policy_document.cloudwatch.tf
@@ -8,4 +8,6 @@ data "aws_iam_policy_document" "cloudwatch" {
     actions   = ["iam:PassRole"]
     resources = [aws_iam_role.cwl.arn]
   }
+
+  version = "2012-10-17"
 }


### PR DESCRIPTION
When policy version is not explicitly set, it's set to a default value. Later when it's read back it does not match and causes spurious changes to show up in the Terraform plan:
`- Version   = "2008-10-17" -> null`